### PR TITLE
fix: concurrent cleanup

### DIFF
--- a/datastore/db.go
+++ b/datastore/db.go
@@ -252,7 +252,9 @@ func (db *Db) mergeOldSegments() error {
 	db.segments = append(shadowDb.segments, db.curSegment())
 
 	for _, segment := range segmentsToMerge {
+		segment.mu.Lock()
 		os.Remove(segment.FilePath())
+		segment.mu.Unlock()
 	}
 
 	return nil


### PR DESCRIPTION
possible error on merge segment cleanup, when a client reads data with a file descriptor that will be removed